### PR TITLE
[BTFS-974] - gRPC panic middleware/interceptors common 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,10 @@ require (
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/go-pg/migrations v6.7.3+incompatible
 	github.com/go-pg/pg v0.0.0-20190627115636-374b7dab11ff
-	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/json-iterator/go v1.1.6
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
-	github.com/stretchr/testify v1.3.0
-	go.uber.org/atomic v1.4.0 // indirect
-	go.uber.org/multierr v1.1.0 // indirect
+	github.com/stretchr/testify v1.4.0
+	github.com/tron-us/go-common/v2 v2.0.4
 	go.uber.org/zap v1.10.0
+	google.golang.org/grpc v1.25.1
 )

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,11 @@ require (
 	github.com/go-pg/migrations/v7 v7.1.6
 	github.com/go-pg/pg/v9 v9.0.1
 	github.com/go-redis/redis/v7 v7.0.0-beta.4
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/json-iterator/go v1.1.6
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
-	github.com/stretchr/testify v1.3.0
-	go.uber.org/atomic v1.4.0 // indirect
-	go.uber.org/multierr v1.1.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.10.0
+	google.golang.org/grpc v1.25.1
 )

--- a/handlers/grpcpanichandler.go
+++ b/handlers/grpcpanichandler.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"runtime"
 
-	"github.com/tron-us/go-common/log"
+	"github.com/tron-us/go-common/v2/log"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/handlers/grpcpanichandler.go
+++ b/handlers/grpcpanichandler.go
@@ -1,12 +1,29 @@
 package handlers
 
 import (
-panichandler "github.com/kazegusuri/grpc-panic-handler"
-"google.golang.org/grpc"
+	"errors"
+	"runtime"
+
+	"github.com/tron-us/go-common/log"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 )
 
 var (
-	UIntOpt = grpc.UnaryInterceptor(panichandler.UnaryPanicHandler)
-	SIntOpt = grpc.StreamInterceptor(panichandler.StreamPanicHandler)
-)
+	// Panic handler prints the stack trace when recovering from a panic.
+	RecoveryCustomFunc grpc_recovery.RecoveryHandlerFunc = grpc_recovery.RecoveryHandlerFunc(func(p interface{}) error {
+		buf := make([]byte, 1<<16)
+		stacklen := runtime.Stack(buf, true)
+		log.Error("Panic attack :", zap.Error(errors.New(string(buf[:stacklen]))))
+		return status.Errorf(codes.Internal, "%s", p)
+	})
+	// Shared options for the logger, with a custom gRPC code to log level function.
+	Opts = []grpc_recovery.Option{
+		grpc_recovery.WithRecoveryHandler(RecoveryCustomFunc),
+	}
 
+	UnaryServerInterceptor = grpc_recovery.UnaryServerInterceptor(Opts...)
+)

--- a/handlers/grpcpanichandler.go
+++ b/handlers/grpcpanichandler.go
@@ -1,0 +1,12 @@
+package handlers
+
+import (
+panichandler "github.com/kazegusuri/grpc-panic-handler"
+"google.golang.org/grpc"
+)
+
+var (
+	UIntOpt = grpc.UnaryInterceptor(panichandler.UnaryPanicHandler)
+	SIntOpt = grpc.StreamInterceptor(panichandler.StreamPanicHandler)
+)
+

--- a/middleware/grpcmiddleware.go
+++ b/middleware/grpcmiddleware.go
@@ -1,4 +1,4 @@
-package handlers
+package middleware
 
 import (
 	"errors"

--- a/middleware/grpcmiddleware.go
+++ b/middleware/grpcmiddleware.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"runtime"
 
-	"github.com/tron-us/go-common/log"
+	"github.com/tron-us/go-common/v2/log"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/middleware/grpcmiddleware.go
+++ b/middleware/grpcmiddleware.go
@@ -7,12 +7,12 @@ import (
 	"runtime/debug"
 
 	"github.com/tron-us/go-common/v2/log"
-	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (

--- a/middleware/grpcmiddleware.go
+++ b/middleware/grpcmiddleware.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"errors"
+	"google.golang.org/grpc"
 	"runtime/debug"
 
 	"github.com/tron-us/go-common/v2/log"
@@ -10,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 )
 
@@ -24,6 +26,10 @@ var (
 	Opts = []grpc_recovery.Option{
 		grpc_recovery.WithRecoveryHandler(RecoveryCustomFunc),
 	}
-
 	UnaryServerInterceptor = grpc_recovery.UnaryServerInterceptor(Opts...)
+	GrpcServerOption       grpc.ServerOption
 )
+
+func init() {
+	GrpcServerOption = grpc_middleware.WithUnaryServerChain(UnaryServerInterceptor)
+}

--- a/middleware/grpcmiddleware.go
+++ b/middleware/grpcmiddleware.go
@@ -1,8 +1,9 @@
 package middleware
 
 import (
+	"bytes"
 	"errors"
-	"runtime"
+	"runtime/debug"
 
 	"github.com/tron-us/go-common/v2/log"
 	"go.uber.org/zap"
@@ -15,9 +16,8 @@ import (
 var (
 	// Panic handler prints the stack trace when recovering from a panic.
 	RecoveryCustomFunc grpc_recovery.RecoveryHandlerFunc = grpc_recovery.RecoveryHandlerFunc(func(p interface{}) error {
-		buf := make([]byte, 1<<16)
-		stacklen := runtime.Stack(buf, true)
-		log.Error("Panic attack :", zap.Error(errors.New(string(buf[:stacklen]))))
+		buf := bytes.NewBuffer(debug.Stack())
+		log.Error("Panic attack :", zap.Error(errors.New(buf.String())))
 		return status.Errorf(codes.Internal, "%s", p)
 	})
 	// Shared options for the logger, with a custom gRPC code to log level function.


### PR DESCRIPTION
Added a panic handler that prints the stack trace when recovering from a panic.

Added shared options for the logger, with a custom gRPC code to log level function.

Added UnaryServerInterceptor handle.

(implementation found in status-server - TRON-US/status-server#74)